### PR TITLE
fix static issue

### DIFF
--- a/src/SeedSpring.php
+++ b/src/SeedSpring.php
@@ -4,7 +4,8 @@ namespace ParagonIE\SeedSpring;
 class SeedSpring
 {
     protected $counter;
-    
+    private $seed;
+
     public function __construct(string $seed = '', int $counter = 0)
     {
         $this->seed('set', $seed);
@@ -21,12 +22,11 @@ class SeedSpring
      */
     private function seed(string $action = 'get', string $data = '')
     {
-        static $seed = null;
         if ($action === 'set') {
-            $seed = $data;
+            $this->seed = $data;
             return;
         } elseif ($action === 'get') {
-            return $data;
+            return $this->seed;
         } else {
             throw new \Error(
                 'Unknown action'

--- a/test/SeedSpringTest.php
+++ b/test/SeedSpringTest.php
@@ -27,4 +27,22 @@ class SeedSpringTest extends PHPUnit_Framework_TestCase
             $int2
         );
     }
+
+    public function testDifferentSeeds()
+    {
+        $seed1 = str_repeat("\x00", 16);
+        $seed2 = str_repeat("\x80", 16);
+
+        $rnd1 = new SeedSpring($seed1);
+        $rnd2 = new SeedSpring($seed2);
+
+        $out1 = $rnd1->getBytes(256);
+        $out2 = $rnd2->getBytes(256);
+
+        $this->assertNotEquals(
+            $out1,
+            $out2,
+            'Different seeds should result in different output'
+        );
+    }
 }


### PR DESCRIPTION
This fixes an issue with using a static variable in a function.

Also, return $data; where $action was 'get' meant that the seed returned was always a blank string.
