### PR TITLE
Implement Fast-Erasure RNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,11 @@ deterministic RNG supports up to 2^128 possible outputs, since it's based on a
 128-bit block cipher.
 
 Our implementation uses AES-128-CTR to turn a finite, 128-bit key into an
-practically endless stream of random bytes. (It will repeat after 2^132 bytes of
-output. You should consider rekeying after 2^66 bytes.)
+practically endless stream of random bytes. 
+
+It will repeat after 2^132 bytes of output. You should consider rekeying after 
+2^66 bytes.
+
+For anything security-sensitive, you should rekey after 2^39 bytes. This is
+because the probability of predicting successive blocks becomes unacceptably
+high for security operations.

--- a/src/FastErasureRNG.php
+++ b/src/FastErasureRNG.php
@@ -1,0 +1,71 @@
+<?php
+namespace ParagonIE\SeedSpring;
+
+use ParagonIE\ConstantTime\Binary;
+use Exception;
+
+class FastErasureRNG
+{
+    /**
+     * @var SeedSpring $seedspring
+     */
+    private $seedspring;
+
+    /**
+     * @param string $initialSeed
+     * @param int $counter
+     */
+    public function __construct($initialSeed = '', $counter = 0)
+    {
+        if (Binary::safeStrlen($initialSeed) !== 32) {
+            throw new \InvalidArgumentException('Seed must be 16 or 32 bytes');
+        }
+        $this->seedspring = new SeedSpring($initialSeed, $counter);
+    }
+
+    /**
+     * Deterministic random byte generator
+     *
+     * @param int $numBytes How many bytes do we want?
+     * @return string
+     */
+    public function getBytes($numBytes)
+    {
+        $allBytes = $this->seedspring->getBytes($numBytes + 32);
+        $return = Binary::safeSubstr($allBytes, 0, $numBytes);
+        $this->seedspring->reseed(
+            Binary::safeSubstr($allBytes, $numBytes, 32)
+        );
+        return $return;
+    }
+
+    /**
+     * Generate a deterministic random integer
+     *
+     * Stolen from paragonie/random_compat
+     *
+     * @param int $min
+     * @param int $max
+     * @return int
+     * @throws Exception
+     */
+    public function getInt($min, $max)
+    {
+        $int = $this->seedspring->getInt($min, $max);
+        $this->seedspring->reseed($this->seedspring->getBytes(32));
+        return $int;
+    }
+
+    /**
+     * Seek to a given position
+     *
+     * @param int $position
+     * @param int $seektype Set to self:SEEK_SET or self::SEEK_INCREASE
+     * @return self
+     */
+    public function seek($position, $seektype = SeedSpring::SEEK_SET)
+    {
+        $this->seedspring->seek($position, $seektype);
+        return $this;
+    }
+}

--- a/test/FastErasureRNGTest.php
+++ b/test/FastErasureRNGTest.php
@@ -1,0 +1,58 @@
+<?php
+use ParagonIE\SeedSpring\FastErasureRNG;
+use ParagonIE\ConstantTime\Binary;
+use ParagonIE\ConstantTime\Hex;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SeedSpringTest
+ */
+class FastErasureRNGTest extends TestCase
+{
+    public function keysProvider()
+    {
+        return [
+            [str_repeat("\x00", 32)],
+            [str_repeat("\xFF", 32)],
+            [random_bytes(32)]
+        ];
+    }
+
+    /**
+     * @dataProvider keysProvider
+     */
+    public function testFastErasure($key)
+    {
+        $rnd1 = new FastErasureRNG($key);
+        $rnd2 = new FastErasureRNG($key);
+        $rnd3 = new FastErasureRNG($key);
+
+        foreach ([4096, 4097, 8192, 16384, 65536] as $test) {
+            $buf1 = '';
+
+            for ($i = 0; $i < $test; $i += 16) {
+                $buf1 .= $rnd1->getBytes(
+                    $i + 16 > $test
+                        ? ($test - $i)
+                        : 16
+                );
+            }
+            $buf2 = $rnd2->getBytes($test);
+            $this->assertSame(
+                Binary::safeStrlen($buf1),
+                Binary::safeStrlen($buf2),
+                'Not the same length - test ' . $test
+            );
+            $this->assertNotSame(
+                $rnd3->seek($test, SEEK_SET)->getBytes(32),
+                $rnd1->getBytes(32),
+                'RNG must rekey, but did not'
+            );
+            $this->assertNotSame(
+                $rnd3->seek($test, SEEK_SET)->getBytes(32),
+                $rnd2->getBytes(32),
+                'RNG must rekey, but did not'
+            );
+        }
+    }
+}

--- a/test/SeedSpringTest.php
+++ b/test/SeedSpringTest.php
@@ -8,10 +8,25 @@ use PHPUnit\Framework\TestCase;
  */
 class SeedSpringTest extends TestCase
 {
-    public function testDeterminism()
-    {
-        $seed = random_bytes(16);
 
+    public function seedProvider()
+    {
+        return [
+            [str_repeat("\x00", 16)],
+            [str_repeat("\x00", 32)],
+            [str_repeat("\xFF", 16)],
+            [str_repeat("\xFF", 32)],
+            [random_bytes(16)],
+            [random_bytes(32)]
+        ];
+    }
+
+    /**
+     * @dataProvider seedProvider
+     * @throws Exception
+     */
+    public function testDeterminism($seed)
+    {
         $rnd1 = new SeedSpring($seed);
         $rnd2 = new SeedSpring($seed);
 
@@ -35,11 +50,11 @@ class SeedSpringTest extends TestCase
 
     /**
      * Our nonce logic needs to match OpenSSL's internals.
+     *
+     * @dataProvider seedProvider
      */
-    public function testCtrModeNonce()
+    public function testCtrModeNonce($seed)
     {
-        $seed = random_bytes(16);
-
         $rnd1 = new SeedSpring($seed);
         $rnd2 = new SeedSpring($seed);
 


### PR DESCRIPTION
See https://blog.cr.yp.to/20170723-random.html

A fast-erasure RNG re-keys itself with an additional 32 bytes of randomness each call.

Additionally, this PR updates the README to make clearer the security limits of AES-CTR.